### PR TITLE
Fix liquid source and usage relations

### DIFF
--- a/src/wikigen/generators/LiquidGenerator.java
+++ b/src/wikigen/generators/LiquidGenerator.java
@@ -5,8 +5,11 @@ import arc.util.*;
 import mindustry.*;
 import mindustry.ctype.*;
 import mindustry.type.*;
+import mindustry.world.*;
 import mindustry.world.blocks.environment.*;
+import mindustry.world.blocks.power.*;
 import mindustry.world.blocks.production.*;
+import mindustry.world.blocks.units.*;
 import mindustry.world.consumers.*;
 import wikigen.*;
 
@@ -18,11 +21,37 @@ public class LiquidGenerator extends FileGenerator<Liquid>{
         boolean pumpable = Vars.content.blocks().contains(b -> b instanceof Floor f && f.liquidDrop == liquid);
 
         return ObjectMap.of(
-            "produced", links(Vars.content.blocks().select(b -> b.minfo.mod == null && (pumpable && b instanceof Pump && !(b instanceof SolidPump sp && sp.result != liquid))
-                || (b instanceof GenericCrafter g && g.outputLiquid != null && g.outputLiquid.liquid == liquid))),
-            "crafting", links(Vars.content.blocks().select(b -> b.minfo.mod == null && b.consumers!= null && Structs.contains(b.consumers, c -> (c instanceof ConsumeLiquidFilter f && f.filter.get(liquid))
-                || (c instanceof ConsumeLiquid l && l.liquid == liquid))))
+            "produced", links(Vars.content.blocks().select(b -> b.minfo.mod == null && (
+                (pumpable && b instanceof Pump && !(b instanceof SolidPump sp && sp.result != liquid))
+                || outputsLiquid(b, liquid)
+            ))),
+            "crafting", links(Vars.content.blocks().select(b -> b.minfo.mod == null && consumesLiquid(b, liquid)))
         );
+    }
+
+    private boolean outputsLiquid(Block block, Liquid liquid){
+        if(block instanceof SolidPump pump && pump.result == liquid) return true;
+
+        if(block instanceof GenericCrafter crafter){
+            if(crafter.outputLiquid != null && crafter.outputLiquid.liquid == liquid) return true;
+            if(crafter.outputLiquids != null && Structs.contains(crafter.outputLiquids, stack -> stack.liquid == liquid)) return true;
+        }
+
+        if(block instanceof ConsumeGenerator generator && generator.outputLiquid != null && generator.outputLiquid.liquid == liquid) return true;
+        if(block instanceof ThermalGenerator generator && generator.outputLiquid != null && generator.outputLiquid.liquid == liquid) return true;
+
+        return false;
+    }
+
+    private boolean consumesLiquid(Block block, Liquid liquid){
+        if(block.consumers != null && Structs.contains(block.consumers, c ->
+            (c instanceof ConsumeLiquidBase base && base.consumes(liquid)) ||
+            (c instanceof ConsumeLiquids liquids && Structs.contains(liquids.liquids, stack -> stack.liquid == liquid))
+        )) return true;
+
+        if(block instanceof UnitAssembler assembler && assembler.plans.contains(plan -> plan.liquidReq != null && Structs.contains(plan.liquidReq, stack -> stack.liquid == liquid))) return true;
+
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Fixes the missing source entry on https://mindustrygame.github.io/wiki/liquids/4-neoplasm/ where Neoplasm did not list the Neoplasia Reactor as its production source.
- Detect liquid outputs from `GenericCrafter.outputLiquids`, `ConsumeGenerator`/`HeaterGenerator`, `ThermalGenerator`, and `SolidPump.result`.
- Detect liquid usage from `ConsumeLiquidBase`, `ConsumeLiquids`, and `UnitAssembler` plan liquid requirements.
- Keeps liquid pages from omitting generator byproducts, solid-pump outputs, multi-liquid consumers, and assembler coolant/production liquids.

## Why this matters
The generated liquid pages currently miss several relations that are present in game code. The most visible example is Neoplasm: the game defines it as an output of the Neoplasia Reactor, but the generated wiki page has no production source.

Other affected examples include solid-pump outputs such as Water Extractor / Oil Extractor results and multi-liquid consumers such as Chemical Combustion Chamber or Pyrolysis Generator.

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew compileJava`
