### PR TITLE
Fix generated item and unit relations

### DIFF
--- a/src/wikigen/generators/ItemGenerator.java
+++ b/src/wikigen/generators/ItemGenerator.java
@@ -5,8 +5,10 @@ import arc.util.*;
 import mindustry.*;
 import mindustry.ctype.*;
 import mindustry.type.*;
+import mindustry.world.*;
 import mindustry.world.blocks.environment.*;
 import mindustry.world.blocks.production.*;
+import mindustry.world.blocks.units.*;
 import mindustry.world.consumers.*;
 import wikigen.*;
 
@@ -15,18 +17,49 @@ public class ItemGenerator extends FileGenerator<Item>{
 
     @Override
     public ObjectMap<String, Object> vars(Item item){
-        boolean drillable = Vars.content.blocks().contains(b -> b instanceof Floor f && f.itemDrop == item);
+        boolean drillable = Vars.content.blocks().contains(b -> b instanceof Floor f && !f.wallOre && f.itemDrop == item);
+        boolean beamDrillable = Vars.content.blocks().contains(b ->
+            (b instanceof Floor f && f.wallOre && f.itemDrop == item) ||
+            (b instanceof StaticWall w && w.itemDrop == item)
+        );
 
         return ObjectMap.of(
             "cost", (int)(item.cost * 100) + "%",
             "hardness", item.hardness,
-            "drillable", drillable,
+            "drillable", drillable || beamDrillable,
             "color", item.color.toString().substring(0, 6),
-            "produced", links(Vars.content.blocks().select(b -> b.minfo.mod == null && ((drillable && b instanceof Drill d && d.tier >= item.hardness) || (b instanceof GenericCrafter g && g.outputItem != null && g.outputItem.item == item)))),
+            "produced", links(Vars.content.blocks().select(b -> b.minfo.mod == null && outputsItem(b, item, drillable, beamDrillable))),
             "used", links(Vars.content.blocks().select(b -> b.minfo.mod == null && b.requirements != null && Structs.contains(b.requirements, i -> i.item == item))),
-            "crafting", links(Vars.content.blocks().select(b -> b.minfo.mod == null && b.consumers != null && Structs.contains(b.consumers, c -> (c instanceof ConsumeItemFilter i && i.filter.get(item))
-                                                                                || (c instanceof ConsumeItems h && Structs.contains(h.items, s -> s.item == item)))))
+            "crafting", links(Vars.content.blocks().select(b -> b.minfo.mod == null && consumesItem(b, item)))
         );
+    }
+
+    private boolean outputsItem(Block block, Item item, boolean drillable, boolean beamDrillable){
+        if(drillable && block instanceof Drill drill && drill.tier >= item.hardness && canMine(drill.blockedItems, item)) return true;
+        if(beamDrillable && block instanceof BeamDrill drill && drill.tier >= item.hardness && canMine(drill.blockedItems, item)) return true;
+        if(block instanceof WallCrafter crafter && crafter.output == item) return true;
+        if(block instanceof Separator separator && separator.results != null && Structs.contains(separator.results, stack -> stack.item == item)) return true;
+
+        if(block instanceof GenericCrafter crafter){
+            if(crafter.outputItem != null && crafter.outputItem.item == item) return true;
+            if(crafter.outputItems != null && Structs.contains(crafter.outputItems, stack -> stack.item == item)) return true;
+        }
+
+        return false;
+    }
+
+    private boolean consumesItem(Block block, Item item){
+        if(block.consumers != null && Structs.contains(block.consumers, c -> (c instanceof ConsumeItemFilter i && i.filter.get(item))
+            || (c instanceof ConsumeItems h && Structs.contains(h.items, s -> s.item == item)))) return true;
+
+        if(block instanceof UnitFactory factory && factory.plans.contains(plan -> Structs.contains(plan.requirements, stack -> stack.item == item))) return true;
+        if(block instanceof UnitAssembler assembler && assembler.plans.contains(plan -> plan.itemReq != null && Structs.contains(plan.itemReq, stack -> stack.item == item))) return true;
+
+        return false;
+    }
+
+    private boolean canMine(Seq<Item> blockedItems, Item item){
+        return blockedItems == null || !blockedItems.contains(item);
     }
 
     @Override

--- a/src/wikigen/generators/UnitGenerator.java
+++ b/src/wikigen/generators/UnitGenerator.java
@@ -4,6 +4,7 @@ import arc.struct.*;
 import mindustry.*;
 import mindustry.ctype.*;
 import mindustry.type.*;
+import mindustry.world.*;
 import mindustry.world.blocks.units.*;
 import wikigen.*;
 
@@ -13,7 +14,14 @@ public class UnitGenerator extends FileGenerator<UnitType>{
     @Override
     public ObjectMap<String, Object> vars(UnitType content){
         return ObjectMap.of(
-        "created", links(Vars.content.blocks().select(b -> b.minfo.mod == null && b instanceof UnitFactory u && u.plans.contains(p -> p.unit == content)))
+        "created", links(Vars.content.blocks().select(b -> b.minfo.mod == null && createsUnit(b, content)))
         );
+    }
+
+    private boolean createsUnit(Block block, UnitType unit){
+        if(block instanceof UnitFactory factory && factory.plans.contains(plan -> plan.unit == unit)) return true;
+        if(block instanceof Reconstructor reconstructor && reconstructor.upgrades.contains(upgrade -> upgrade.length > 1 && upgrade[1] == unit)) return true;
+        if(block instanceof UnitAssembler assembler && assembler.plans.contains(plan -> plan.unit == unit)) return true;
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- Add item source detection for wall ores mined by `BeamDrill`, wall crushers, multi-output crafters, and `Separator.results`.
- Add item usage detection for dynamic unit factory and unit assembler plans.
- Add unit source detection for reconstructors and unit assemblers, not just unit factories.

## Why this matters
Several generated pages currently omit relationships that are defined in game code:

- Sand does not list Cliff Crusher / Large Cliff Crusher as production sources.
- Beryllium and Tungsten do not list Plasma Bore / Large Plasma Bore as production sources.
- Separator and Disassembler outputs are missing from item source lists.
- Higher-tier unit pages only include factories and miss Reconstructors or Unit Assemblers.
- Items consumed by unit factories/assemblers are missing from the generated item usage lists because those requirements are dynamic consumers.

The omissions come from missing Mindustry block classes and dynamic plan structures in the relation generation code.

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew compileJava`
