### PR TITLE
Fix generated unit internal names

### DIFF
--- a/src/wikigen/FileGenerator.java
+++ b/src/wikigen/FileGenerator.java
@@ -41,15 +41,33 @@ public class FileGenerator<T extends UnlockableContent>{
     public String format(String temp, ObjectMap<String, Object> vars){
         StringBuilder template = new StringBuilder(temp);
         vars.put("repo", repo);
-        //sort keys by length so longer variables get replaced with invalid symbols first
+        //sort keys by length and replace full variable tokens so prefixes don't corrupt longer names
         Seq<String> keys = vars.keys().toSeq().sort(s -> -s.length());
         keys.each(key -> {
             var val = vars.get(key);
             var str = Generator.str(val);
-            Strings.replace(template, "$" + key, str.isEmpty() ? "$INVALID!" : str);
+            replaceVariable(template, key, str.isEmpty() ? "$INVALID!" : str);
         });
 
         return Strings.join("\n", Seq.with(template.toString().split("\n")).select(s -> !s.contains("$")));
+    }
+
+    private void replaceVariable(StringBuilder template, String key, String value){
+        String token = "$" + key;
+        int index = 0;
+        while((index = template.indexOf(token, index)) != -1){
+            int end = index + token.length();
+            if(end < template.length()){
+                char next = template.charAt(end);
+                if(Character.isLetterOrDigit(next) || next == '_'){
+                    index = end;
+                    continue;
+                }
+            }
+
+            template.replace(index, end, value);
+            index += value.length();
+        }
     }
 
     /** Returns a markdown file with this name in the output directory with this generator's type name.*/

--- a/src/wikigen/Generator.java
+++ b/src/wikigen/Generator.java
@@ -132,6 +132,7 @@ public class Generator{
                                 values.put("" + field.getName(), field.get(content));
                             }
 
+                            values.put("internalname", content.name);
                             values.putAll(generator.vars(content));
                             values.put("stats", MockScene.scrapeStats(content));
 


### PR DESCRIPTION
## Summary
- Populate the `$internalname` template variable from `content.name` for generated content pages.
- Replace only complete `$variable` tokens so shorter variable names cannot corrupt longer placeholders.

## Why this matters
`templates/unit.md` expects `$internalname`, but the generator did not provide that value. `UnitType` also has a boolean `internal` field, and the previous prefix-based replacement could turn `$internalname` into values like `Noname` instead of the unit's internal name.

A visible example is the generated Dagger page: its `Internal Name` row currently renders as `Noname`; it should render as `dagger`.

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew compileJava`
