### PR TITLE
Avoid links to hidden generated content

### DIFF
--- a/src/wikigen/FileGenerator.java
+++ b/src/wikigen/FileGenerator.java
@@ -87,6 +87,7 @@ public class FileGenerator<T extends UnlockableContent>{
     /** @return a markdown image link to this content.*/
     @SuppressWarnings("unchecked")
     public final String link(UnlockableContent content){
+        if(content.isHidden()) return content.localizedName;
         return Generator.get(content.getContentType()).makeLink(content);
     }
 

--- a/src/wikigen/image/MockScene.java
+++ b/src/wikigen/image/MockScene.java
@@ -119,7 +119,7 @@ public class MockScene{
     }
 
     static String link(UnlockableContent content){
-        return Generator.get(content.getContentType()).makeLink(content);
+        return Generator.get(content.getContentType()).link(content);
     }
 
     static void display(Element e, StringBuilder result){


### PR DESCRIPTION
## Summary
- Render hidden content references as plain localized names instead of links to generated pages.
- Route stat-scraped content references through the same link helper so hidden content is handled consistently.

## Why this matters
Hidden content is skipped by page generation, so links to hidden content become dead links in generated stats. Current generated pages include examples such as:

- Slag Centrifuge linking to `/wiki/liquids/6-gallium` for hidden Gallium.
- Heat Reactor linking to `/wiki/items/20-fissile-matter` for hidden Fissile Matter.
- Mud linking to `/wiki/statuses/7-muddy` for the hidden Muddy status.

These names should still be shown in stats, but not as links to pages that are not generated.

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew compileJava`
